### PR TITLE
Minor clarifications

### DIFF
--- a/s20/lab1/jupyter.md
+++ b/s20/lab1/jupyter.md
@@ -4,7 +4,11 @@
 
 2. Before we install Jupyter, let's get pip.  Run the following, and enter "Y" when prompted:
 
-`sudo apt install python3-pip`
+```
+sudo apt update
+sudo apt upgrade
+sudo apt install python3-pip
+```
 
 The `apt` program lets you install software on an Ubuntu system; think
 of it like `pip`, for more general (you can install stuff not related
@@ -25,7 +29,7 @@ able to take over your VM!  Run the following:
 
 5. Now let's start Jupyter.  Run the following:
 
-`python3 -m notebook --ip=0.0.0.0 --port=2020`
+`python3 -m notebook --no-browser --ip=0.0.0.0 --port=2020`
 
 6. Now, open up a new browser window, and type `IP:2020` for the URL
 (IP should be the External IP of the virtual machine).  You can enter

--- a/s20/lab1/ssh.md
+++ b/s20/lab1/ssh.md
@@ -9,7 +9,8 @@ where we need to paste a key, which we haven't generated yet.
 
 <img src="img/14.png" width=600>
 
-3. Open your terminal, and run the command `ssh-keygen`.  It looks
+3. Open your terminal, and run the command `ssh-keygen`.  You should be able
+to just use the defaults by hitting enter a few times. It looks
 like the following on a Mac, but should work the same on Windows.  If
 `ssh-keygen` isn't found, then you should skip the rest of this
 section and go back to the next steps on the [main page](README.md)
@@ -29,3 +30,5 @@ username that appears to the left of the box (in this case "trh") --
 you'll need it later.
 
 <img src="img/17.png" width=600>
+
+6. Then click "Save".


### PR DESCRIPTION
I needed to run apt update/upgrade, otherwise, pip3 wasn't found and installed. 
The --no-browser option makes sure it doesn't launch a remote browser (for when they end up installing chrome, maybe for selenium).
Also, why change the default port for jupyter? Is 8888 not good?  