### PR TITLE
replaced cs301 references with cs320 for linter and test notebook

### DIFF
--- a/s20/p1/test.py
+++ b/s20/p1/test.py
@@ -16,7 +16,7 @@ except ImportError:
     err_msg = """Please download lint.py and place it in this directory for 
     the tests to run correctly. If you haven't yet looked at the linting module, 
     it is designed to help you improve your code so take a look at: 
-    https://github.com/tylerharter/cs320/raw/master/linter/lint.py"""
+    https://github.com/tylerharter/cs320/tree/master/linter"""
     raise FileNotFoundError(err_msg)
 
 ALLOWED_LINT_ERRS = {

--- a/s20/p1/test.py
+++ b/s20/p1/test.py
@@ -16,7 +16,7 @@ except ImportError:
     err_msg = """Please download lint.py and place it in this directory for 
     the tests to run correctly. If you haven't yet looked at the linting module, 
     it is designed to help you improve your code so take a look at: 
-    https://github.com/tylerharter/cs301-projects/tree/master/linter"""
+    https://github.com/tylerharter/cs320/raw/master/linter/lint.py"""
     raise FileNotFoundError(err_msg)
 
 ALLOWED_LINT_ERRS = {
@@ -131,7 +131,7 @@ def extract_question_num(cell):
 
 # rerun notebook and return parsed JSON
 def rerun_notebook(orig_notebook):
-    new_notebook = 'cs-301-test.ipynb'
+    new_notebook = 'cs-320-test.ipynb'
 
     # re-execute it from the beginning
     with open(orig_notebook, encoding='utf-8') as f:


### PR DESCRIPTION
The notebook that test.py outputs was named `cs-301-test.ipynb`, so I changed it to `cs-320-test.ipynb`. I also updated the link to the linter error message to be the same as the one found at [https://github.com/tylerharter/cs320/tree/master/s20/p1](https://github.com/tylerharter/cs320/tree/master/s20/p1)